### PR TITLE
[DPLAT-1310] To changed the default VARCHAR from VARCHAR(65535) to VARCHAR(256). 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ classpath/
 build/
 .idea
 *.iml
+*.jar

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # JDBC output plugins for Embulk
 
+**Forked to change behavior of Embulk string columns: we default VARCHAR for these columns, previously the default was CLOB.**
+
 JDBC output plugins for Embulk loads records to databases using JDBC drivers.
 
 ## MySQL

--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java
@@ -892,8 +892,8 @@ public abstract class AbstractJdbcOutputPlugin
                 public void stringColumn(Column column)
                 {
                     columns.add(JdbcColumn.newGenericTypeColumn(
-                            columnName, Types.CLOB, "CLOB",
-                            4000, 0, false, false));  // TODO size type param
+                            columnName, Types.VARCHAR, "VARCHAR",
+                            256, 0, false, false));  // TODO size type param
                 }
 
                 public void jsonColumn(Column column)

--- a/embulk-output-redshift/src/main/java/org/embulk/output/redshift/RedshiftOutputConnection.java
+++ b/embulk-output-redshift/src/main/java/org/embulk/output/redshift/RedshiftOutputConnection.java
@@ -48,11 +48,8 @@ public class RedshiftOutputConnection
     @Override
     protected String buildColumnTypeName(JdbcColumn c)
     {
-        // Redshift does not support TEXT type.
         switch(c.getSimpleTypeName()) {
         case "CLOB":
-            return "VARCHAR(65535)";
-        case "TEXT":
             return "VARCHAR(65535)";
         case "BLOB":
             return "BYTEA";


### PR DESCRIPTION
[DPLAT-1310](https://classydev.atlassian.net/browse/DPLAT-1310) - ETL - update Embulk to use appropriately sized text columns by default